### PR TITLE
Prevent Flow from checking node_modules, add Prettier config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,6 @@
+[declarations]
+<PROJECT_ROOT>/node_modules/.*
+
 [ignore]
 
 [include]
@@ -8,4 +11,5 @@
 
 [options]
 exact_by_default=true
+
 [strict]

--- a/package.json
+++ b/package.json
@@ -98,10 +98,28 @@
     "singleQuote": false,
     "quoteProps": "as-needed",
     "jsxSingleQuote": false,
-    "trailingComma": "none",
+    "trailingComma": "all",
     "bracketSpacing": true,
     "jsxBracketSameLine": false,
-    "arrowParens": "avoid"
+    "arrowParens": "always",
+    "overrides": [
+      {
+        "files": [
+          "src/Editor.js",
+          "src/index.js",
+          "src/layers.js",
+          "src/layers.test.js",
+          "src/pushID.js",
+          "src/reorder.js",
+          "src/reorder.test.js",
+          "src/useKeys.js"
+        ],
+        "options": {
+          "trailingComma": "none",
+          "arrowParens": "avoid"
+        }
+      }
+    ]
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -90,6 +90,19 @@
       "transform-flow-strip-types"
     ]
   },
+  "prettier": {
+    "printWidth": 80,
+    "tabWidth": 2,
+    "useTabs": false,
+    "semi": true,
+    "singleQuote": false,
+    "quoteProps": "as-needed",
+    "jsxSingleQuote": false,
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "jsxBracketSameLine": false,
+    "arrowParens": "avoid"
+  },
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
Some tools try to run Flow checks on files in `node_modules` which have the `@flow` pragma. These errors aren't relevant. We can prevent this by using the declarations config:

- https://github.com/facebook/flow/issues/869
- https://flow.org/en/docs/config/declarations/#toc-declarations

Also baked in the Prettier config we're using to avoid tools falling back to some other config.