### PR TITLE
Replace the "author" field with "contributors"

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     {
       "name": "Haydn Ewers",
       "url": "https://particlesystem.com/"
+    },
+    {
+      "name": "Michael Tran",
+      "url": "https://github.com/Mxchaeltrxn"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,12 @@
     "graphic"
   ],
   "main": "cli/index.js",
-  "author": "Hayden Ewers",
+  "contributors": [
+    {
+      "name": "Haydn Ewers",
+      "url": "https://particlesystem.com/"
+    }
+  ],
   "license": "MIT",
   "bugs": "https://github.com/sketchbook-js/sketchbook/issues",
   "homepage": "https://github.com/sketchbook-js/sketchbook#readme",


### PR DESCRIPTION
Using "contributors" to allow multiple people to be listed:

https://docs.npmjs.com/cli/v6/configuring-npm/package-json#people-fields-author-contributors

@Mxchaeltrxn Want to add yourself here too (both URL and email are optional)?