### PR TITLE
Add github actions build pipeline

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,21 +1,20 @@
-name: Build
+name: build-ci
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
+    env:
+      NODE_VER: 10
 
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ env.NODE_VER }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ env.NODE_VER }}
     - run: yarn install
     - run: yarn test
     - run: yarn build

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn install
+    - run: yarn test
+    - run: yarn build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: node_js
-script: yarn test && yarn build

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </h1>
   <p>The design tool that lives in your repo.</p>
   <p>
-    <a href="https://travis-ci.org/github/sketchbook-js/sketchbook"><img alt="Travis CI build status" src="https://img.shields.io/travis/sketchbook-js/sketchbook" /></a>
+    <a href="https://github.com/sketchbook-js/sketchbook/actions"><img alt="Github Actions CI build status" src="https://img.shields.io/github/workflow/status/sketchbook-js/sketchbook/build-ci/master" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
## Changes made
- Remove travis ci badge and add github actions badge
- Add github actions pipeline and remove travis ci pipeline.

Closes #147 

Took a while to get the badge right ... but I got it to work in the end. I actually think it was a bit flaky but not sure why.

I've pointed the badge to master branch so it won't work until it is merged to master but the screenshot below was when it was pointed to this branch.

![image](https://user-images.githubusercontent.com/34886045/123491001-f755e600-d658-11eb-8797-078b3addfeae.png)

## Other notes
I've used node version 10 because that's the version specified in `.nvmrc`.

Also I get a weird language format error when I named the build file `build.yml` so I just changed the name ... I don't think there's anything wrong with naming it `build.yml` though