### PR TITLE
Ref/request response

### DIFF
--- a/src/canvas/useEditorConnection.js
+++ b/src/canvas/useEditorConnection.js
@@ -1,38 +1,58 @@
 import { useState, useEffect } from "react";
+import pushID from "../pushID";
 
 const useEditorConnection = (editorWindow, canvasWindow) => {
   const [layersToRender, setLayersToRender] = useState([]);
   const [layersToMeasure, setLayersToMeasure] = useState([]);
+  const [sketchbookRequestMeasureId, setSketchbookRequestMeasureId] = useState(
+    undefined
+  );
+
   useEffect(() => {
     const receiveMessage = event => {
       switch (event.data.type) {
         case "sketchbook_request:ping": {
-          editorWindow.postMessage(
-            {
-              type: "sketchbook_response:acknowledge",
-              status: "ready"
-            },
-            "*"
-          );
+          postSketchbookMessageAcknowledge();
           break;
         }
         case "sketchbook_request:render": {
+          postSketchbookMessageAcknowledge();
           setLayersToRender(event.data.layers);
           break;
         }
         case "sketchbook_request:measure": {
+          setSketchbookRequestMeasureId(event.data.id);
           setLayersToMeasure(current => [...current, event.data.layer]);
           break;
         }
         default:
           break;
       }
+
+      function postSketchbookMessageAcknowledge() {
+        editorWindow.postMessage(
+          {
+            type: "sketchbook_response:acknowledge",
+            id: pushID(),
+            request: event.data.id,
+            status: "ready"
+          },
+          "*"
+        );
+      }
     };
     canvasWindow.addEventListener("message", receiveMessage);
     return () => {
       canvasWindow.removeEventListener("message", receiveMessage);
     };
-  }, [setLayersToRender, setLayersToMeasure, canvasWindow, editorWindow]);
+  }, [
+    setLayersToRender,
+    setLayersToMeasure,
+    canvasWindow,
+    editorWindow,
+    sketchbookRequestMeasureId
+  ]);
+
   return {
     layersToRender,
     layersToMeasure,
@@ -41,6 +61,7 @@ const useEditorConnection = (editorWindow, canvasWindow) => {
         {
           type: "sketchbook_response:measure",
           id,
+          request: sketchbookRequestMeasureId,
           width,
           height
         },

--- a/src/canvas/useEditorConnection.js
+++ b/src/canvas/useEditorConnection.js
@@ -6,21 +6,21 @@ const useEditorConnection = (editorWindow, canvasWindow) => {
   useEffect(() => {
     const receiveMessage = event => {
       switch (event.data.type) {
-        case "sketchbook_status_request": {
+        case "sketchbook_request:ping": {
           editorWindow.postMessage(
             {
-              type: "sketchbook_status_response",
+              type: "sketchbook_response:acknowledge",
               status: "ready"
             },
             "*"
           );
           break;
         }
-        case "sketchbook_render_layers_request": {
+        case "sketchbook_request:render": {
           setLayersToRender(event.data.layers);
           break;
         }
-        case "sketchbook_measure_layer_request": {
+        case "sketchbook_request:measure": {
           setLayersToMeasure(current => [...current, event.data.layer]);
           break;
         }
@@ -39,7 +39,7 @@ const useEditorConnection = (editorWindow, canvasWindow) => {
     sendMeasurements: ({ id, width, height }) => {
       editorWindow.postMessage(
         {
-          type: "sketchbook_measure_layer_response",
+          type: "sketchbook_response:measure",
           id,
           width,
           height

--- a/src/editor/useCanvasConnection.js
+++ b/src/editor/useCanvasConnection.js
@@ -5,20 +5,26 @@ import pushID from "../pushID";
 const useCanvasStatus = (editorWindow, canvasRef) => {
   const [status, setStatus] = useState("unknown");
   useEffect(() => {
+    const messageRequestId = pushID();
     const interval = setInterval(() => {
       if (!canvasRef.current) throw Error("No canvas");
       canvasRef.current.contentWindow.postMessage(
         {
-          type: "sketchbook_request:ping"
+          type: "sketchbook_request:ping",
+          id: messageRequestId
         },
         "*"
       );
     }, 100);
-    const receiveMessage = event => {
-      if (event.data.type === "sketchbook_response:acknowledge") {
+    const receiveMessage = ({
+      data: { type: eventType, request: eventRequest, status: messageStatus }
+    }) => {
+      if (
+        eventType === "sketchbook_response:acknowledge" &&
+        eventRequest === messageRequestId
+      ) {
         clearInterval(interval);
-        editorWindow.removeEventListener("message", receiveMessage);
-        setStatus(event.data.status);
+        setStatus(messageStatus);
       }
     };
     editorWindow.addEventListener("message", receiveMessage);
@@ -26,34 +32,49 @@ const useCanvasStatus = (editorWindow, canvasRef) => {
       clearInterval(interval);
       editorWindow.removeEventListener("message", receiveMessage);
     };
-  }, [canvasRef, editorWindow]);
+  }, [canvasRef, editorWindow, status]);
   return status;
 };
 
-const useCanvasRender = (status, canvasRef, layers) => {
+const useCanvasRender = ({ editorWindow, status, canvasRef, layers }) => {
   useEffect(() => {
+    const messageRequestId = pushID();
     if (status === "ready") {
       if (!canvasRef.current) throw Error("No canvas");
       canvasRef.current.contentWindow.postMessage(
         {
           type: "sketchbook_request:render",
+          id: messageRequestId,
           layers
         },
         "*"
       );
     }
-  }, [status, canvasRef, layers]);
+    const receiveMessage = ({
+      data: { type: eventType, request: eventRequest }
+    }) => {
+      if (
+        eventType === "sketchbook_response:acknowledge" &&
+        eventRequest === messageRequestId
+      ) {
+      }
+    };
+    editorWindow.addEventListener("message", receiveMessage);
+    return () => {
+      editorWindow.removeEventListener("message", receiveMessage);
+    };
+  }, [status, canvasRef, layers, editorWindow]);
 };
 
 const useCanvasMeasure = (status, editorWindow, canvasRef) => {
   return ({ type, component, width, height, options }) => {
     return new Promise((resolve, reject) => {
       if (status === "ready" && canvasRef.current) {
-        const id = pushID();
+        const messageRequestId = pushID();
         const receiveMessage = event => {
           if (
             event.data.type === "sketchbook_response:measure" &&
-            event.data.id === id
+            event.data.request === messageRequestId
           ) {
             resolve({ width: event.data.width, height: event.data.height });
             editorWindow.removeEventListener("message", receiveMessage);
@@ -63,8 +84,9 @@ const useCanvasMeasure = (status, editorWindow, canvasRef) => {
         canvasRef.current.contentWindow.postMessage(
           {
             type: "sketchbook_request:measure",
+            id: messageRequestId,
             layer: {
-              id,
+              id: pushID(),
               type,
               component,
               width,
@@ -83,9 +105,11 @@ const useCanvasMeasure = (status, editorWindow, canvasRef) => {
 
 const useCanvasConnection = (editorWindow, canvasRef, layers) => {
   const status = useCanvasStatus(editorWindow, canvasRef);
-  useCanvasRender(status, canvasRef, layers);
+  useCanvasRender({ editorWindow, status, canvasRef, layers });
   const measureLayer = useCanvasMeasure(status, editorWindow, canvasRef);
-  return { measureLayer };
+  return {
+    measureLayer
+  };
 };
 
 export default useCanvasConnection;

--- a/src/editor/useCanvasConnection.js
+++ b/src/editor/useCanvasConnection.js
@@ -9,13 +9,13 @@ const useCanvasStatus = (editorWindow, canvasRef) => {
       if (!canvasRef.current) throw Error("No canvas");
       canvasRef.current.contentWindow.postMessage(
         {
-          type: "sketchbook_status_request"
+          type: "sketchbook_request:ping"
         },
         "*"
       );
     }, 100);
     const receiveMessage = event => {
-      if (event.data.type === "sketchbook_status_response") {
+      if (event.data.type === "sketchbook_response:acknowledge") {
         clearInterval(interval);
         editorWindow.removeEventListener("message", receiveMessage);
         setStatus(event.data.status);
@@ -36,7 +36,7 @@ const useCanvasRender = (status, canvasRef, layers) => {
       if (!canvasRef.current) throw Error("No canvas");
       canvasRef.current.contentWindow.postMessage(
         {
-          type: "sketchbook_render_layers_request",
+          type: "sketchbook_request:render",
           layers
         },
         "*"
@@ -52,7 +52,7 @@ const useCanvasMeasure = (status, editorWindow, canvasRef) => {
         const id = pushID();
         const receiveMessage = event => {
           if (
-            event.data.type === "sketchbook_measure_layer_response" &&
+            event.data.type === "sketchbook_response:measure" &&
             event.data.id === id
           ) {
             resolve({ width: event.data.width, height: event.data.height });
@@ -62,7 +62,7 @@ const useCanvasMeasure = (status, editorWindow, canvasRef) => {
         editorWindow.addEventListener("message", receiveMessage);
         canvasRef.current.contentWindow.postMessage(
           {
-            type: "sketchbook_measure_layer_request",
+            type: "sketchbook_request:measure",
             layer: {
               id,
               type,


### PR DESCRIPTION
@haydn Closes #150.

## What I've done
I've done everything mentioned on #150 except for the last one, which says
> Update the sketchbook_response:measure request to have a layer field

The reason I've left this out is because I'm not entirely sure what this means (or what it's for). It also isn't in sync with the protocol specific in #149. Maybe you can clarify this a bit in this PR?

## Some other notes:
- I've also added the `request` property to the protocol messages.
- I've removed the `removeEventListener` on line 26 of `useCanvasConnection.js` because according to the protocol, the `sketchbook_response:acknowledge` response should listen more than once for `sketchbook_request:ping` requests (in case of canvas disconnection, for example).
- On line 87 and 89 of `useCanvasConnection.js`, I've used a different id to avoid any confusion between the ids even though they can technically be the same since they're unrelated.

 